### PR TITLE
merge(#57): gnome_ui.shortcuts

### DIFF
--- a/doc/cli/tasks.md
+++ b/doc/cli/tasks.md
@@ -229,3 +229,53 @@ Task to configure the `gnome` environment on the host.
   }
 }
 ```
+
+#### Configure Gnome.shortcuts (UI)
+
+- `gnome`
+    - `shortcuts_wm` (*keybinding[]*): Configure `org.gnome.desktop.wm.keybindings`. By default (`[]`). You can see defined *key bindings* with
+      `gsettings list-recursively org.gnome.desktop.wm.keybindings`.
+        - *name*: The action name to bind, see `gsettings list-keys org.gnome.desktop.wm.keybindings`,
+        - *key*: The key to bind, example `<Alt>F4`.
+    - `shortcuts_mutter` (*keybinding[]*): Configure `org.gnome.mutter.keybindings`. By default (`[]`). You can see defined *key bindings* with
+      `gsettings list-recursively org.gnome.mutter.keybindings`.
+        - *name*: The action name to bind, see `gsettings list-keys org.gnome.mutter.keybindings`,
+        - *key*: The key to bind, example `<Super>Right`.
+    - `shortcuts_shell` (*keybinding[]*): Configure `org.gnome.shell.keybindings`. By default (`[]`). You can see defined *key bindings* with
+      `gsettings list-recursively org.gnome.shell.keybindings`.
+        - *name*: The action name to bind, see `gsettings list-keys org.gnome.shell.keybindings`,
+        - *key*: The key to bind, example `<Super>s`.
+    - `shortcuts_media_keys` (*keybinding[]*): Configure `org.gnome.settings-daemon.plugins.media-keys`. By default (`[]`). You can see defined *key bindings* with
+      `gsettings list-recursively org.gnome.settings-daemon.plugins.media-keys`.
+        - *name*: The action name to bind, see `gsettings list-keys org.gnome.settings-daemon.plugins.media-keys`,
+        - *key*: The key to bind, example `<Control><Alt>Delete`.
+    - `shortcuts_custom` (*keybinding[]*): Add custom *key bindings*. By default (`[]`). 
+        - *name*: The key binding name, example `terminal`.
+        - *key*: The key to bind, example `<Super>1`.
+        - *command*: The command to execute, example `gnome-terminal`.
+
+```json
+{
+  ...
+  "vars": {
+    "gnome": {
+      "shortcuts_wm":[
+        {"name": "close", "key": "<Alt>F4"}
+      ],
+      "shortcuts_mutter":[
+        {"name": "toggle-tiled-right", "key": "<Super>Right"}
+      ],
+      "shortcuts_shell":[
+        {"name": "toggle-overview", "key": "<Super>s"}
+      ],
+      "shortcuts_media_keys":[
+        {"name": "logout", "key": "<Control><Alt>Delete"}
+      ],
+      "shortcuts_custom":[
+        {"name": "terminal", "key": "<Super>1", "command": "gnome-terminal"},
+        {"name": "monitor", "key": "<Super>2", "command": "gnome-system-monitor"}
+      ]
+    }
+  }
+}
+```

--- a/src/playbooks/roles/gnome:ui/defaults/main.yml
+++ b/src/playbooks/roles/gnome:ui/defaults/main.yml
@@ -12,3 +12,9 @@ __gnome_extensions_configure:
     - schema: org.gnome.shell.extensions.window-list
       key: show-on-all-monitors
       value: "false"
+
+__gnome_shortcuts_wm: []
+__gnome_shortcuts_mutter: []
+__gnome_shortcuts_shell: []
+__gnome_shortcuts_media_keys: []
+__gnome_shortcuts_custom: []

--- a/src/playbooks/roles/gnome:ui/tasks/main.yml
+++ b/src/playbooks/roles/gnome:ui/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - include: extensions.yml
+- include: shortcuts.yml

--- a/src/playbooks/roles/gnome:ui/tasks/shortcuts.yml
+++ b/src/playbooks/roles/gnome:ui/tasks/shortcuts.yml
@@ -1,0 +1,35 @@
+---
+- name: (shortcuts) configure org.gnome.desktop.wm.keybindings
+  shell: "gsettings set org.gnome.desktop.wm.keybindings {{ item.name }} '[{{ item.key | to_json }}]'"
+  with_items: "{{ __gnome_shortcuts_wm }}"
+
+- name: (shortcuts) configure org.gnome.mutter.keybindings
+  shell: "gsettings set org.gnome.mutter.keybindings {{ item.name }} '[{{ item.key | to_json }}]'"
+  with_items: "{{ __gnome_shortcuts_mutter }}"
+
+- name: (shortcuts) configure org.gnome.shell.keybindings
+  shell: "gsettings set org.gnome.shell.keybindings {{ item.name }} '[{{ item.key | to_json }}]'"
+  with_items: "{{ __gnome_shortcuts_shell }}"
+
+- name: (shortcuts) configure org.gnome.settings-daemon.plugins.media-keys
+  shell: "gsettings set org.gnome.settings-daemon.plugins.media-keys {{ item.name }} '{{ item.key }}'"
+  with_items: "{{ __gnome_shortcuts_media_keys }}"
+
+- name: (shortcuts) set fact
+  set_fact:
+    __gnome_shortcuts_custom_computed: "{{ __gnome_shortcuts_custom|map(attribute='name') | map('regex_replace', '(.*)', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/\\g<1>/') | list  }}"
+
+- name: (shortcuts) create customs
+  shell: "gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings '{{ __gnome_shortcuts_custom_computed | to_json }}' "
+
+- name: (shortcuts) configure customs name
+  shell: "gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/{{ item.name }}/ name '{{ item.name | escape }}'"
+  with_items: "{{ __gnome_shortcuts_custom }}"
+
+- name: (shortcuts) configure customs command
+  shell: "gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/{{ item.name }}/ command '{{ item.command | escape }}'"
+  with_items: "{{ __gnome_shortcuts_custom }}"
+
+- name: (shortcuts) configure customs binding
+  shell: "gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/{{ item.name }}/ binding '{{ item.key }}'"
+  with_items: "{{ __gnome_shortcuts_custom }}"


### PR DESCRIPTION
merge(#57): gnome_ui.shortcuts

Configure:
- `org.gnome.desktop.wm.keybindings`
- `org.gnome.mutter.keybindings`
- `org.gnome.shell.keybindings`
- `org.gnome.settings-daemon.plugins.media-keys`
- `org.gnome.settings-daemon.plugins.media-keys.custom-keybinding`

Tags: us-9, gnome, ui, shortcuts